### PR TITLE
Add option file for the oXygen web author with a setting for the DITA-OT

### DIFF
--- a/containers/oxywebauthor-dfst/Dockerfile
+++ b/containers/oxywebauthor-dfst/Dockerfile
@@ -17,6 +17,7 @@ RUN curl --silent --show-error --fail --location \
 ADD settings.xml /usr/local/tomcat/conf/
 ADD tomcat-users.xml /usr/local/tomcat/conf/
 ADD license.properties /usr/local/tomcat/webapps/oxygenxml-web-author/WEB-INF/
+ADD options.xml /usr/local/tomcat/work/Catalina/localhost/oxygenxml-web-author/options/
 RUN ls /usr/local/tomcat/webapps/oxygenxml-web-author/WEB-INF/
 
 #

--- a/containers/oxywebauthor-dfst/options.xml
+++ b/containers/oxywebauthor-dfst/options.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serialized version="18.1" xml:space="preserve">
+	<map>
+		<entry>
+			<String>dita.ot.directory</String>
+			<String>/DITA-OT</String>
+		</entry>
+	</map>
+</serialized>


### PR DESCRIPTION
This adds an options.xml file which specifies the location of the DITA-OT.

**Important:** 
You need to change that to the actual location of the shared DITA-OT, which is made available to the web author container